### PR TITLE
Update mozilla.cfg

### DIFF
--- a/Files/mozilla.cfg
+++ b/Files/mozilla.cfg
@@ -54,7 +54,7 @@ pref("extensions.shield-recipe-client.api_url", "");
 pref("extensions.shield-recipe-client.enabled", false);
 pref("extensions.webservice.discoverURL", "");
 pref("general.warnOnAboutConfig", false);
-pref("keyword.enabled", false);
+pref("keyword.enabled", true);
 pref("media.autoplay.default", 1);
 pref("media.autoplay.enabled", false);
 pref("media.eme.enabled", false);


### PR DESCRIPTION
pref("keyword.enabled", false); prevents user from searching directly in the url section. While this can be fixed with a simple redirect with utilizing a shortcut key such as "d" for duckduckgo, this makes it easier by nature and does not make someone have to retrain their brain. 
pref("keyword.enabled", true);  allows the user to directly search via url field